### PR TITLE
Delete endpoint cleanups

### DIFF
--- a/src/apis/callbacks.py
+++ b/src/apis/callbacks.py
@@ -120,7 +120,6 @@ async def cb_collection_ready(
         try:
             collection = data["collection"]
             session.vector_store_id = collection["knowledge_base_id"]
-            session.collection_id = collection["id"]
         except (KeyError, TypeError) as err:
             logger.error("malformed collection-ready payload for %s: %s", session_id, err)
             session.error_message = "collection creation returned malformed payload"

--- a/src/file_search/session.py
+++ b/src/file_search/session.py
@@ -23,7 +23,6 @@ class OpenAISessionState(BaseModel):
     status: SessionStatusEnum = SessionStatusEnum.active
     vector_store_id: Optional[str] = None    # was: assistant_id
     conversation_id: Optional[str] = None    # was: thread_id
-    collection_id: Optional[str] = None      # for DELETE /collections/{id} on cleanup
 
     # In-flight per-query-call state. Reset by the Celery task at task start.
     queries: list[str] = []

--- a/src/services/ai_platform_src.py
+++ b/src/services/ai_platform_src.py
@@ -158,26 +158,15 @@ def llm_call(
 
 
 def delete_document(document_id: str) -> bool:
-    """Delete a document from kaapi. UNCHANGED."""
-    delete_url = f"{BASE_URI}/documents/{document_id}"
+    """
+    Permanently delete a document from kaapi. And does all the cleanup (delete collection, vector store etc.)
+    """
+    delete_url = f"{BASE_URI}/documents/{document_id}/permanent"
     res = http_delete(delete_url, headers=HEADERS)
 
     if not res.get("success", False):
         raise HTTPException(
             status_code=500,
             detail=f"Failed to delete document {document_id}: {res.get('error')}",
-        )
-    return True
-
-
-def delete_collection(collection_id: str) -> bool:
-    """Delete a collection (vector store) from kaapi. NEW for cleanup."""
-    delete_url = f"{BASE_URI}/collections/{collection_id}"
-    res = http_delete(delete_url, headers=HEADERS)
-
-    if not res.get("success", False):
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to delete collection {collection_id}: {res.get('error')}",
         )
     return True

--- a/src/utils/celery_tasks.py
+++ b/src/utils/celery_tasks.py
@@ -133,9 +133,9 @@ def query_file_v1(
 def close_file_search_session_v1(self, session_id: str):
     """
     Cleanup at session close:
-      1. DELETE the kaapi collection (vector store) if we know its id.
-      2. DELETE each kaapi document we uploaded.
-      3. Remove the session record from Redis.
+      1. Permanently delete each kaapi document we uploaded. Kaapi cascades
+         this to detach from the collection / vector store and free storage.
+      2. Remove the session record from Redis.
 
     Failures on individual deletes are logged but do not abort the rest —
     we want best-effort cleanup so a stuck remote resource doesn't leak forever.
@@ -146,14 +146,6 @@ def close_file_search_session_v1(self, session_id: str):
             logger.info("close_file_search_session_v1: session %s already gone",
                         session_id)
             return
-
-        if session.collection_id:
-            logger.info("Deleting kaapi collection %s", session.collection_id)
-            try:
-                ai_platform_src.delete_collection(session.collection_id)
-            except Exception as err:
-                logger.warning("Failed to delete collection %s: %s",
-                               session.collection_id, err)
 
         for document_id in session.document_ids or []:
             logger.info("Deleting kaapi document %s", document_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documents uploaded for file search are now permanently deleted when sessions end for proper cleanup.

* **Chores**
  * Updated internal vector store management to prevent unnecessary collection deletion during session cleanup, improving data persistence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/ai-llm-service/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->